### PR TITLE
Make compatible with browserify

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require(__dirname + '/lib/getopt.js');
+module.exports = require('./lib/getopt.js');


### PR DESCRIPTION
Require lib/ from relative path instead of __dirname
