### PR TITLE
remove __dirname from require command to prevent crashing in bundled …

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require(__dirname + '/lib/getopt.js');
+module.exports = require('./lib/getopt.js');


### PR DESCRIPTION
…environments like runtimejs

When bundling node-getopt through browserfy style bundlers, using `__dirname` vs `./` causes it to add folder paths that wont exist.  Using `./` fixes this issue.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jiangmiao/node-getopt/8)

<!-- Reviewable:end -->
