### PR TITLE
Add license info to the package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "featured command line args parser",
   "keywords" : ["getopt", "arg", "parser"],
   "homepage": "http://github.com/jiangmiao/node-getopt",
+  "license": "MIT",
   "repository" : {
     "type" : "git",
     "url" : "git://github.com/jiangmiao/node-getopt.git"


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com). By adding the license info to the package.json it becomes available through the public NPMRegistry API and that way other tools like VersionEye can fetch it easier.