### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require(__dirname + '/lib/getopt.js');
+module.exports = require('./lib/getopt.js');


### PR DESCRIPTION
Use relative path to fetch module. Noticed when debugging packaging problems with "pkg":

pkg/prelude/bootstrap.js:1172
      throw error;
      ^

Error: Cannot find module '/snapshot/agent/node_modules/node-getopt/lib/getopt.js'
1) If you want to compile the package/file into executable, please pay attention to compilation warnings and specify a literal in 'require' call. 2) If you don't want to compile the package/file into executable and want to 'require' it from filesystem (likely plugin), specify an absolute path in 'require' call using process.cwd() or process.execPath.
    at Function.Module._resolveFilename (module.js:540:15)
    at Function.Module._resolveFilename (pkg/prelude/bootstrap.js:1269:46)
    at Function.Module._load (module.js:470:25)
    at Module.require (module.js:583:17)
    at Module.require (pkg/prelude/bootstrap.js:1153:31)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/snapshot/agent/node_modules/node-getopt/index.js:0:0)
    at Module._compile (pkg/prelude/bootstrap.js:1243:22)
    at Object.Module._extensions..js (module.js:650:10)
    at Module.load (module.js:558:32)