### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
     "type" : "git",
     "url" : "https://github.com/jiangmiao/node-getopt"
   },
-  "main" : "./lib",
+  "main" : "lib",
   "engines" : { "node": ">= 0.6.0" }
 }


### PR DESCRIPTION
Build complains about 

(node:24) [DEP0128] DeprecationWarning: Invalid 'main' field in '/home/container/node_modules/node-getopt/package.json' of './lib'. Please either fix that or report it to the module author